### PR TITLE
feat: infra -> be -> peatio w deps -> account -> update hook -> enqueue -> specs

### DIFF
--- a/spec/serializers/serializers/event_api/order_canceled_spec.rb
+++ b/spec/serializers/serializers/event_api/order_canceled_spec.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 # frozen_string_literal: true
 
 describe Serializers::EventAPI::OrderCanceled do
@@ -7,17 +6,17 @@ describe Serializers::EventAPI::OrderCanceled do
   let :order_ask do
     # Sell 100 BTC for 3 USD (0.03 USD per BTC).
     create :order_ask, \
-      bid:           :usd,
-      ask:           :btc,
-      market:        Market.find_spot_by_symbol(:btcusd),
-      state:         :wait,
-      ord_type:      :limit,
-      price:         '0.03'.to_d,
-      volume:        '100.0',
-      origin_volume: '100.0',
-      locked:        '100.0',
-      origin_locked: '100.0',
-      member:        seller
+           bid: :usd,
+           ask: :btc,
+           market: Market.find_spot_by_symbol(:btcusd),
+           state: :wait,
+           ord_type: :limit,
+           price: '0.03'.to_d,
+           volume: '100.0',
+           origin_volume: '100.0',
+           locked: '100.0',
+           origin_locked: '100.0',
+           member: seller
   end
 
   subject { order_ask }
@@ -37,28 +36,29 @@ describe Serializers::EventAPI::OrderCanceled do
     DatabaseCleaner.clean
     EventAPI.expects(:notify).with('market.btcusd.order_created', anything).once
     EventAPI.expects(:notify).with('market.btcusd.order_canceled', {
-      id:                       1,
-      market:                  'btcusd',
-      type:                    'sell',
-      trader_uid:              seller.uid,
-      income_unit:             'usd',
-      income_fee_type:         'relative',
-      income_maker_fee_value:  '0.0015',
-      income_taker_fee_value:  '0.0015',
-      outcome_unit:            'btc',
-      outcome_fee_type:        'relative',
-      outcome_fee_value:       '0.0',
-      initial_income_amount:   '3.0',
-      current_income_amount:   '3.0',
-      initial_outcome_amount:  '100.0',
-      current_outcome_amount:  '100.0',
-      strategy:                'limit',
-      price:                   '0.03',
-      state:                   'canceled',
-      trades_count:            0,
-      created_at:              created_at.iso8601,
-      canceled_at:             canceled_at.iso8601
-    }).once
+                                     id: 1,
+                                     market: 'btcusd',
+                                     type: 'sell',
+                                     trader_uid: seller.uid,
+                                     income_unit: 'usd',
+                                     income_fee_type: 'relative',
+                                     income_maker_fee_value: '0.0015',
+                                     income_taker_fee_value: '0.0015',
+                                     outcome_unit: 'btc',
+                                     outcome_fee_type: 'relative',
+                                     outcome_fee_value: '0.0',
+                                     initial_income_amount: '3.0',
+                                     current_income_amount: '3.0',
+                                     initial_outcome_amount: '100.0',
+                                     current_outcome_amount: '100.0',
+                                     strategy: 'limit',
+                                     price: '0.03',
+                                     state: 'canceled',
+                                     trades_count: 0,
+                                     created_at: created_at.iso8601,
+                                     canceled_at: canceled_at.iso8601
+                                   }).once
+    EventAPI.expects(:enqueue_event).with("private.#{seller.uid}.account", anything)
   end
 
   after do

--- a/spec/serializers/serializers/event_api/order_completed_spec.rb
+++ b/spec/serializers/serializers/event_api/order_completed_spec.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 # frozen_string_literal: true
 
 describe Serializers::EventAPI::OrderCompleted do
@@ -7,17 +6,17 @@ describe Serializers::EventAPI::OrderCompleted do
   let :order_ask do
     # Sell 100 BTC for 3 USD (0.03 USD per BTC).
     create :order_ask, \
-      bid:           :usd,
-      ask:           :btc,
-      market:        Market.find_spot_by_symbol(:btcusd),
-      state:         :wait,
-      ord_type:      :limit,
-      price:         '0.03'.to_d,
-      volume:        '100.0',
-      origin_volume: '100.0',
-      locked:        '100.0',
-      origin_locked: '100.0',
-      member:        seller
+           bid: :usd,
+           ask: :btc,
+           market: Market.find_spot_by_symbol(:btcusd),
+           state: :wait,
+           ord_type: :limit,
+           price: '0.03'.to_d,
+           volume: '100.0',
+           origin_volume: '100.0',
+           locked: '100.0',
+           origin_locked: '100.0',
+           member: seller
   end
 
   subject { order_ask }
@@ -37,30 +36,31 @@ describe Serializers::EventAPI::OrderCompleted do
     DatabaseCleaner.clean
     EventAPI.expects(:notify).with('market.btcusd.order_created', anything).once
     EventAPI.expects(:notify).with('market.btcusd.order_completed', {
-      id:                      1,
-      market:                  'btcusd',
-      type:                    'sell',
-      trader_uid:              seller.uid,
-      income_unit:             'usd',
-      income_fee_type:         'relative',
-      income_maker_fee_value:  '0.0015',
-      income_taker_fee_value:  '0.0015',
-      outcome_unit:            'btc',
-      outcome_fee_type:        'relative',
-      outcome_fee_value:       '0.0',
-      initial_income_amount:   '3.0',
-      current_income_amount:   '0.0',
-      previous_income_amount:  '3.0',
-      initial_outcome_amount:  '100.0',
-      current_outcome_amount:  '0.0',
-      previous_outcome_amount: '100.0',
-      strategy:                'limit',
-      price:                   '0.03',
-      state:                   'completed',
-      trades_count:            1,
-      created_at:              created_at.iso8601,
-      completed_at:            completed_at.iso8601
-    }).once
+                                     id: 1,
+                                     market: 'btcusd',
+                                     type: 'sell',
+                                     trader_uid: seller.uid,
+                                     income_unit: 'usd',
+                                     income_fee_type: 'relative',
+                                     income_maker_fee_value: '0.0015',
+                                     income_taker_fee_value: '0.0015',
+                                     outcome_unit: 'btc',
+                                     outcome_fee_type: 'relative',
+                                     outcome_fee_value: '0.0',
+                                     initial_income_amount: '3.0',
+                                     current_income_amount: '0.0',
+                                     previous_income_amount: '3.0',
+                                     initial_outcome_amount: '100.0',
+                                     current_outcome_amount: '0.0',
+                                     previous_outcome_amount: '100.0',
+                                     strategy: 'limit',
+                                     price: '0.03',
+                                     state: 'completed',
+                                     trades_count: 1,
+                                     created_at: created_at.iso8601,
+                                     completed_at: completed_at.iso8601
+                                   }).once
+    EventAPI.expects(:enqueue_event).with("private.#{seller.uid}.account", anything)
   end
 
   after do
@@ -69,10 +69,10 @@ describe Serializers::EventAPI::OrderCompleted do
 
   it 'publishes event', clean_database_with_truncation: true do
     subject.update! \
-    volume:         0,
-    locked:         0,
-    funds_received: 100,
-    trades_count:   1,
-    state:          Order::DONE
+      volume: 0,
+      locked: 0,
+      funds_received: 100,
+      trades_count: 1,
+      state: Order::DONE
   end
 end

--- a/spec/serializers/serializers/event_api/order_created_spec.rb
+++ b/spec/serializers/serializers/event_api/order_created_spec.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 # frozen_string_literal: true
 
 describe Serializers::EventAPI::OrderCreated do
@@ -7,17 +6,17 @@ describe Serializers::EventAPI::OrderCreated do
   let :order_bid do
     # Buy 14 BTC for 0.42 USD (0.03 USD per BTC).
     create :order_bid, \
-      bid:           :usd,
-      ask:           :btc,
-      market:        Market.find_spot_by_symbol(:btcusd),
-      state:         :wait,
-      ord_type:      :limit,
-      price:         '0.03'.to_d,
-      volume:        '14.0',
-      origin_volume: '14.0',
-      locked:        '0.42',
-      origin_locked: '0.42',
-      member:        buyer
+           bid: :usd,
+           ask: :btc,
+           market: Market.find_spot_by_symbol(:btcusd),
+           state: :wait,
+           ord_type: :limit,
+           price: '0.03'.to_d,
+           volume: '14.0',
+           origin_volume: '14.0',
+           locked: '0.42',
+           origin_locked: '0.42',
+           member: buyer
   end
 
   subject { order_bid }
@@ -34,27 +33,28 @@ describe Serializers::EventAPI::OrderCreated do
   before do
     DatabaseCleaner.clean
     EventAPI.expects(:notify).with('market.btcusd.order_created', {
-      id:                     1,
-      market:                 'btcusd',
-      type:                   'buy',
-      trader_uid:             buyer.uid,
-      income_unit:            'btc',
-      income_fee_type:        'relative',
-      income_maker_fee_value:  '0.0015',
-      income_taker_fee_value:  '0.0015',
-      outcome_unit:           'usd',
-      outcome_fee_type:       'relative',
-      outcome_fee_value:      '0.0',
-      initial_income_amount:  '14.0',
-      current_income_amount:  '14.0',
-      initial_outcome_amount: '0.42',
-      current_outcome_amount: '0.42',
-      strategy:               'limit',
-      price:                  '0.03',
-      state:                  'open',
-      trades_count:           0,
-      created_at:             created_at.iso8601
-    }).once
+                                     id: 1,
+                                     market: 'btcusd',
+                                     type: 'buy',
+                                     trader_uid: buyer.uid,
+                                     income_unit: 'btc',
+                                     income_fee_type: 'relative',
+                                     income_maker_fee_value: '0.0015',
+                                     income_taker_fee_value: '0.0015',
+                                     outcome_unit: 'usd',
+                                     outcome_fee_type: 'relative',
+                                     outcome_fee_value: '0.0',
+                                     initial_income_amount: '14.0',
+                                     current_income_amount: '14.0',
+                                     initial_outcome_amount: '0.42',
+                                     current_outcome_amount: '0.42',
+                                     strategy: 'limit',
+                                     price: '0.03',
+                                     state: 'open',
+                                     trades_count: 0,
+                                     created_at: created_at.iso8601
+                                   }).once
+    EventAPI.expects(:enqueue_event).with("private.#{buyer.uid}.account", anything)
   end
 
   after do

--- a/spec/serializers/serializers/event_api/order_updated_spec.rb
+++ b/spec/serializers/serializers/event_api/order_updated_spec.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 # frozen_string_literal: true
 
 describe Serializers::EventAPI::OrderUpdated, OrderAsk do
@@ -7,17 +6,17 @@ describe Serializers::EventAPI::OrderUpdated, OrderAsk do
   let :order_ask do
     # Sell 100 BTC for 3 USD (0.03 USD per BTC).
     create :order_ask, \
-      bid:           :usd,
-      ask:           :btc,
-      market:        Market.find_spot_by_symbol(:btcusd),
-      state:         :wait,
-      ord_type:      :limit,
-      price:         '0.03'.to_d,
-      volume:        '100.0',
-      origin_volume: '100.0',
-      locked:        '100.0',
-      origin_locked: '100.0',
-      member:        seller
+           bid: :usd,
+           ask: :btc,
+           market: Market.find_spot_by_symbol(:btcusd),
+           state: :wait,
+           ord_type: :limit,
+           price: '0.03'.to_d,
+           volume: '100.0',
+           origin_volume: '100.0',
+           locked: '100.0',
+           origin_locked: '100.0',
+           member: seller
   end
 
   subject { order_ask }
@@ -37,30 +36,31 @@ describe Serializers::EventAPI::OrderUpdated, OrderAsk do
     DatabaseCleaner.clean
     EventAPI.expects(:notify).with('market.btcusd.order_created', anything)
     EventAPI.expects(:notify).with('market.btcusd.order_updated', {
-      id:                      1,
-      market:                  'btcusd',
-      type:                    'sell',
-      trader_uid:              seller.uid,
-      income_unit:             'usd',
-      income_fee_type:         'relative',
-      income_maker_fee_value:  '0.0015',
-      income_taker_fee_value:  '0.0015',
-      outcome_unit:            'btc',
-      outcome_fee_type:        'relative',
-      outcome_fee_value:       '0.0',
-      initial_income_amount:   '3.0',
-      current_income_amount:   '2.4',
-      previous_income_amount:  '3.0',
-      initial_outcome_amount:  '100.0',
-      current_outcome_amount:  '80.0',
-      previous_outcome_amount: '100.0',
-      strategy:                'limit',
-      price:                   '0.03',
-      state:                   'open',
-      trades_count:            1,
-      created_at:              created_at.iso8601,
-      updated_at:              updated_at.iso8601
-    }).once
+                                     id: 1,
+                                     market: 'btcusd',
+                                     type: 'sell',
+                                     trader_uid: seller.uid,
+                                     income_unit: 'usd',
+                                     income_fee_type: 'relative',
+                                     income_maker_fee_value: '0.0015',
+                                     income_taker_fee_value: '0.0015',
+                                     outcome_unit: 'btc',
+                                     outcome_fee_type: 'relative',
+                                     outcome_fee_value: '0.0',
+                                     initial_income_amount: '3.0',
+                                     current_income_amount: '2.4',
+                                     previous_income_amount: '3.0',
+                                     initial_outcome_amount: '100.0',
+                                     current_outcome_amount: '80.0',
+                                     previous_outcome_amount: '100.0',
+                                     strategy: 'limit',
+                                     price: '0.03',
+                                     state: 'open',
+                                     trades_count: 1,
+                                     created_at: created_at.iso8601,
+                                     updated_at: updated_at.iso8601
+                                   }).once
+    EventAPI.expects(:enqueue_event).with("private.#{seller.uid}.account", anything)
   end
 
   after do
@@ -70,10 +70,10 @@ describe Serializers::EventAPI::OrderUpdated, OrderAsk do
   it 'publishes event', clean_database_with_truncation: true do
     subject.transaction do
       subject.update! \
-        volume:         80,
-        locked:         80,
+        volume: 80,
+        locked: 80,
         funds_received: 20,
-        trades_count:   1
+        trades_count: 1
     end
   end
 end
@@ -84,17 +84,17 @@ describe Serializers::EventAPI::OrderUpdated, OrderBid do
   let :order_bid do
     # Buy 14 BTC for 0.42 USD (0.03 USD per BTC).
     create :order_bid, \
-      bid:           :usd,
-      ask:           :btc,
-      market:        Market.find_spot_by_symbol(:btcusd),
-      state:         :wait,
-      ord_type:      :limit,
-      price:         '0.03'.to_d,
-      volume:        '14.0',
-      origin_volume: '14.0',
-      locked:        '0.42',
-      origin_locked: '0.42',
-      member:        buyer
+           bid: :usd,
+           ask: :btc,
+           market: Market.find_spot_by_symbol(:btcusd),
+           state: :wait,
+           ord_type: :limit,
+           price: '0.03'.to_d,
+           volume: '14.0',
+           origin_volume: '14.0',
+           locked: '0.42',
+           origin_locked: '0.42',
+           member: buyer
   end
 
   subject { order_bid }
@@ -114,30 +114,31 @@ describe Serializers::EventAPI::OrderUpdated, OrderBid do
     DatabaseCleaner.clean
     EventAPI.expects(:notify).with('market.btcusd.order_created', anything)
     EventAPI.expects(:notify).with('market.btcusd.order_updated', {
-      id:                      1,
-      market:                  'btcusd',
-      type:                    'buy',
-      trader_uid:              buyer.uid,
-      income_unit:             'btc',
-      income_fee_type:         'relative',
-      income_maker_fee_value:  '0.0015',
-      income_taker_fee_value:  '0.0015',
-      outcome_unit:            'usd',
-      outcome_fee_type:        'relative',
-      outcome_fee_value:       '0.0',
-      initial_income_amount:   '14.0',
-      current_income_amount:   '12.0',
-      previous_income_amount:  '14.0',
-      initial_outcome_amount:  '0.42',
-      current_outcome_amount:  '0.36',
-      previous_outcome_amount: '0.42',
-      strategy:                'limit',
-      price:                   '0.03',
-      state:                   'open',
-      trades_count:            1,
-      created_at:              created_at.iso8601,
-      updated_at:              updated_at.iso8601
-    }).once
+                                     id: 1,
+                                     market: 'btcusd',
+                                     type: 'buy',
+                                     trader_uid: buyer.uid,
+                                     income_unit: 'btc',
+                                     income_fee_type: 'relative',
+                                     income_maker_fee_value: '0.0015',
+                                     income_taker_fee_value: '0.0015',
+                                     outcome_unit: 'usd',
+                                     outcome_fee_type: 'relative',
+                                     outcome_fee_value: '0.0',
+                                     initial_income_amount: '14.0',
+                                     current_income_amount: '12.0',
+                                     previous_income_amount: '14.0',
+                                     initial_outcome_amount: '0.42',
+                                     current_outcome_amount: '0.36',
+                                     previous_outcome_amount: '0.42',
+                                     strategy: 'limit',
+                                     price: '0.03',
+                                     state: 'open',
+                                     trades_count: 1,
+                                     created_at: created_at.iso8601,
+                                     updated_at: updated_at.iso8601
+                                   }).once
+    EventAPI.expects(:enqueue_event).with("private.#{buyer.uid}.account", anything)
   end
 
   after do
@@ -147,10 +148,10 @@ describe Serializers::EventAPI::OrderUpdated, OrderBid do
   it 'publishes event', clean_database_with_truncation: true do
     subject.transaction do
       subject.update! \
-        volume:         12,
-        locked:         0.36,
+        volume: 12,
+        locked: 0.36,
         funds_received: 2,
-        trades_count:   1
+        trades_count: 1
     end
   end
 end

--- a/spec/serializers/serializers/event_api/trade_completed_spec.rb
+++ b/spec/serializers/serializers/event_api/trade_completed_spec.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 # frozen_string_literal: true
 
 describe Serializers::EventAPI::TradeCompleted, 'Event API' do
@@ -8,62 +7,62 @@ describe Serializers::EventAPI::TradeCompleted, 'Event API' do
 
   let :order_ask_maker do
     create :order_ask, \
-      bid:           :usd,
-      ask:           :btc,
-      market:        Market.find_spot_by_symbol(:btcusd),
-      state:         :wait,
-      ord_type:      :limit,
-      price:         '0.03'.to_d,
-      volume:        '100.0',
-      origin_volume: '100.0',
-      locked:        '100.0',
-      origin_locked: '100.0',
-      member:        maker
+           bid: :usd,
+           ask: :btc,
+           market: Market.find_spot_by_symbol(:btcusd),
+           state: :wait,
+           ord_type: :limit,
+           price: '0.03'.to_d,
+           volume: '100.0',
+           origin_volume: '100.0',
+           locked: '100.0',
+           origin_locked: '100.0',
+           member: maker
   end
 
   let :order_ask_taker do
     create :order_ask, \
-      bid:           :usd,
-      ask:           :btc,
-      market:        Market.find_spot_by_symbol(:btcusd),
-      state:         :wait,
-      ord_type:      :limit,
-      price:         '0.03'.to_d,
-      volume:        '100.0',
-      origin_volume: '100.0',
-      locked:        '100.0',
-      origin_locked: '100.0',
-      member:        taker
+           bid: :usd,
+           ask: :btc,
+           market: Market.find_spot_by_symbol(:btcusd),
+           state: :wait,
+           ord_type: :limit,
+           price: '0.03'.to_d,
+           volume: '100.0',
+           origin_volume: '100.0',
+           locked: '100.0',
+           origin_locked: '100.0',
+           member: taker
   end
 
   let :order_bid_maker do
     create :order_bid, \
-      bid:           :usd,
-      ask:           :btc,
-      market:        Market.find_spot_by_symbol(:btcusd),
-      state:         :wait,
-      ord_type:      :limit,
-      price:         '0.03'.to_d,
-      volume:        '14.0',
-      origin_volume: '14.0',
-      locked:        '0.42',
-      origin_locked: '0.42',
-      member:        maker
+           bid: :usd,
+           ask: :btc,
+           market: Market.find_spot_by_symbol(:btcusd),
+           state: :wait,
+           ord_type: :limit,
+           price: '0.03'.to_d,
+           volume: '14.0',
+           origin_volume: '14.0',
+           locked: '0.42',
+           origin_locked: '0.42',
+           member: maker
   end
 
   let :order_bid_taker do
     create :order_bid, \
-      bid:           :usd,
-      ask:           :btc,
-      market:        Market.find_spot_by_symbol(:btcusd),
-      state:         :wait,
-      ord_type:      :limit,
-      price:         '0.03'.to_d,
-      volume:        '14.0',
-      origin_volume: '14.0',
-      locked:        '0.42',
-      origin_locked: '0.42',
-      member:        taker
+           bid: :usd,
+           ask: :btc,
+           market: Market.find_spot_by_symbol(:btcusd),
+           state: :wait,
+           ord_type: :limit,
+           price: '0.03'.to_d,
+           volume: '14.0',
+           origin_volume: '14.0',
+           locked: '0.42',
+           origin_locked: '0.42',
+           member: taker
   end
 
   let(:completed_at) { Time.current }
@@ -75,12 +74,12 @@ describe Serializers::EventAPI::TradeCompleted, 'Event API' do
       Matching::Executor.new \
         action: 'execute',
         trade: {
-          market_id:    :btcusd,
-          maker_order_id:       ask.id,
-          taker_order_id:       bid.id,
+          market_id: :btcusd,
+          maker_order_id: ask.id,
+          taker_order_id: bid.id,
           strike_price: '0.03',
-          amount:       '14.0',
-          total:        '0.42'
+          amount: '14.0',
+          total: '0.42'
         }
     end
 
@@ -105,26 +104,28 @@ describe Serializers::EventAPI::TradeCompleted, 'Event API' do
       EventAPI.expects(:notify).with('market.btcusd.order_updated', anything).once
       EventAPI.expects(:notify).with('market.btcusd.order_completed', anything).once
       EventAPI.expects(:notify).with('market.btcusd.trade_completed', {
-        id:                     1,
-        market:                 'btcusd',
-        price:                  '0.03',
-        amount:                 '14.0',
-        maker_uid:              maker.uid,
-        maker_income_unit:      'usd',
-        maker_income_amount:    '0.42',
-        maker_income_fee:       '0.00063',
-        maker_outcome_unit:     'btc',
-        maker_outcome_amount:   '14.0',
-        maker_outcome_fee:      '0.0',
-        taker_uid:              taker.uid,
-        taker_income_unit:      'btc',
-        taker_income_amount:    '14.0',
-        taker_income_fee:       '0.021',
-        taker_outcome_unit:     'usd',
-        taker_outcome_amount:   '0.42',
-        taker_outcome_fee:      '0.0',
-        completed_at:           completed_at.iso8601
-      }).once
+                                       id: 1,
+                                       market: 'btcusd',
+                                       price: '0.03',
+                                       amount: '14.0',
+                                       maker_uid: maker.uid,
+                                       maker_income_unit: 'usd',
+                                       maker_income_amount: '0.42',
+                                       maker_income_fee: '0.00063',
+                                       maker_outcome_unit: 'btc',
+                                       maker_outcome_amount: '14.0',
+                                       maker_outcome_fee: '0.0',
+                                       taker_uid: taker.uid,
+                                       taker_income_unit: 'btc',
+                                       taker_income_amount: '14.0',
+                                       taker_income_fee: '0.021',
+                                       taker_outcome_unit: 'usd',
+                                       taker_outcome_amount: '0.42',
+                                       taker_outcome_fee: '0.0',
+                                       completed_at: completed_at.iso8601
+                                     }).once
+      EventAPI.expects(:enqueue_event).with("private.#{maker.uid}.account", anything)
+      EventAPI.expects(:enqueue_event).with("private.#{taker.uid}.account", anything)
     end
 
     after do
@@ -145,12 +146,12 @@ describe Serializers::EventAPI::TradeCompleted, 'Event API' do
       Matching::Executor.new \
         action: 'execute',
         trade: {
-          market_id:    :btcusd,
-          maker_order_id:       bid.id,
-          taker_order_id:       ask.id,
+          market_id: :btcusd,
+          maker_order_id: bid.id,
+          taker_order_id: ask.id,
           strike_price: '0.03',
-          amount:       '14.0',
-          total:        '0.42'
+          amount: '14.0',
+          total: '0.42'
         }
     end
 
@@ -175,26 +176,28 @@ describe Serializers::EventAPI::TradeCompleted, 'Event API' do
       EventAPI.expects(:notify).with('market.btcusd.order_updated', anything).once
       EventAPI.expects(:notify).with('market.btcusd.order_completed', anything).once
       EventAPI.expects(:notify).with('market.btcusd.trade_completed', {
-        id:                     1,
-        market:                 'btcusd',
-        price:                  '0.03',
-        amount:                 '14.0',
-        maker_uid:              maker.uid,
-        maker_income_unit:      'btc',
-        maker_income_amount:    '14.0',
-        maker_income_fee:       '0.021',
-        maker_outcome_unit:     'usd',
-        maker_outcome_amount:   '0.42',
-        maker_outcome_fee:      '0.0',
-        taker_uid:              taker.uid,
-        taker_income_unit:      'usd',
-        taker_income_amount:    '0.42',
-        taker_income_fee:       '0.00063',
-        taker_outcome_unit:     'btc',
-        taker_outcome_amount:   '14.0',
-        taker_outcome_fee:      '0.0',
-        completed_at:           completed_at.iso8601
-      }).once
+                                       id: 1,
+                                       market: 'btcusd',
+                                       price: '0.03',
+                                       amount: '14.0',
+                                       maker_uid: maker.uid,
+                                       maker_income_unit: 'btc',
+                                       maker_income_amount: '14.0',
+                                       maker_income_fee: '0.021',
+                                       maker_outcome_unit: 'usd',
+                                       maker_outcome_amount: '0.42',
+                                       maker_outcome_fee: '0.0',
+                                       taker_uid: taker.uid,
+                                       taker_income_unit: 'usd',
+                                       taker_income_amount: '0.42',
+                                       taker_income_fee: '0.00063',
+                                       taker_outcome_unit: 'btc',
+                                       taker_outcome_amount: '14.0',
+                                       taker_outcome_fee: '0.0',
+                                       completed_at: completed_at.iso8601
+                                     }).once
+      EventAPI.expects(:enqueue_event).with("private.#{maker.uid}.account", anything)
+      EventAPI.expects(:enqueue_event).with("private.#{taker.uid}.account", anything)
     end
 
     after do


### PR DESCRIPTION
Балансы на кошельках публикуются через websocket
https://github.com/bitzlato/peatio/issues/8 п.1

Спеки не проверены на CI.
Если не пройдут, предполагается revert e592f904
`feat: infra -> be -> peatio w deps -> account -> update hook -> enqueue -> specs`