### PR TITLE
Feature/8 enqueue account nospecs

### DIFF
--- a/spec/serializers/serializers/event_api/order_canceled_spec.rb
+++ b/spec/serializers/serializers/event_api/order_canceled_spec.rb
@@ -59,6 +59,7 @@ describe Serializers::EventAPI::OrderCanceled do
       created_at:              created_at.iso8601,
       canceled_at:             canceled_at.iso8601
     }).once
+    EventAPI.expects(:enqueue_event).with("private.#{seller.uid}.account", anything)
   end
 
   after do

--- a/spec/serializers/serializers/event_api/order_completed_spec.rb
+++ b/spec/serializers/serializers/event_api/order_completed_spec.rb
@@ -61,6 +61,7 @@ describe Serializers::EventAPI::OrderCompleted do
       created_at:              created_at.iso8601,
       completed_at:            completed_at.iso8601
     }).once
+    EventAPI.expects(:enqueue_event).with("private.#{seller.uid}.account", anything)
   end
 
   after do

--- a/spec/serializers/serializers/event_api/order_created_spec.rb
+++ b/spec/serializers/serializers/event_api/order_created_spec.rb
@@ -55,6 +55,7 @@ describe Serializers::EventAPI::OrderCreated do
       trades_count:           0,
       created_at:             created_at.iso8601
     }).once
+    EventAPI.expects(:enqueue_event).with("private.#{buyer.uid}.account", anything)
   end
 
   after do

--- a/spec/serializers/serializers/event_api/order_updated_spec.rb
+++ b/spec/serializers/serializers/event_api/order_updated_spec.rb
@@ -61,6 +61,7 @@ describe Serializers::EventAPI::OrderUpdated, OrderAsk do
       created_at:              created_at.iso8601,
       updated_at:              updated_at.iso8601
     }).once
+    EventAPI.expects(:enqueue_event).with("private.#{seller.uid}.account", anything)
   end
 
   after do
@@ -138,6 +139,7 @@ describe Serializers::EventAPI::OrderUpdated, OrderBid do
       created_at:              created_at.iso8601,
       updated_at:              updated_at.iso8601
     }).once
+    EventAPI.expects(:enqueue_event).with("private.#{buyer.uid}.account", anything)
   end
 
   after do

--- a/spec/serializers/serializers/event_api/trade_completed_spec.rb
+++ b/spec/serializers/serializers/event_api/trade_completed_spec.rb
@@ -125,6 +125,8 @@ describe Serializers::EventAPI::TradeCompleted, 'Event API' do
         taker_outcome_fee:      '0.0',
         completed_at:           completed_at.iso8601
       }).once
+      EventAPI.expects(:enqueue_event).with("private.#{maker.uid}.account", anything)
+      EventAPI.expects(:enqueue_event).with("private.#{taker.uid}.account", anything)
     end
 
     after do
@@ -195,6 +197,8 @@ describe Serializers::EventAPI::TradeCompleted, 'Event API' do
         taker_outcome_fee:      '0.0',
         completed_at:           completed_at.iso8601
       }).once
+      EventAPI.expects(:enqueue_event).with("private.#{maker.uid}.account", anything)
+      EventAPI.expects(:enqueue_event).with("private.#{taker.uid}.account", anything)
     end
 
     after do


### PR DESCRIPTION
Балансы на кошельках публикуются через websocket
https://github.com/bitzlato/peatio/issues/8 п.1

Спеки не проверены на CI.

Если не пройдут, предполагается revert 00bcf659
feat: infra -> be -> peatio w deps -> account -> update hook -> enqueue -> specs