### PR TITLE
Feat(#8): Fire account msg to ws on order and trade events

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -16,8 +16,6 @@ class Account < ApplicationRecord
   scope :visible, -> { joins(:currency).merge(Currency.where(visible: true)) }
   scope :ordered, -> { joins(:currency).order(position: :asc) }
 
-  after_commit :trigger_event, on: %i[create update]
-
   def as_json_for_event_api
     {
       id: id,
@@ -57,7 +55,9 @@ class Account < ApplicationRecord
   end
 
   def attributes_after_plus_locked_funds!(amount)
-    raise AccountError, "Cannot add funds (account id: #{id}, amount: #{amount}, locked: #{locked})." if amount <= ZERO
+    if amount <= ZERO
+      raise AccountError, "Cannot add funds (account id: #{id}, amount: #{amount}, locked: #{locked})."
+    end
 
     { locked: locked + amount }
   end
@@ -132,10 +132,6 @@ class Account < ApplicationRecord
 
   def amount
     balance + locked
-  end
-
-  def trigger_event
-    ::AMQP::Queue.enqueue_event('private', member&.uid, :account, as_json_for_event_api)
   end
 end
 

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -122,7 +122,8 @@ class Order < ApplicationRecord
         order = lock.find_by_id!(id)
         return unless order.state == ::Order::PENDING
 
-        order.hold_account!.lock_funds!(order.locked)
+        account = order.hold_account!
+        account.lock_funds!(order.locked)
         order.record_submit_operations!
         order.update!(state: ::Order::WAIT)
 
@@ -143,10 +144,12 @@ class Order < ApplicationRecord
       return order.trigger_third_party_cancellation unless market_engine.peatio_engine?
 
       ActiveRecord::Base.transaction do
-        order.hold_account!.unlock_funds!(order.locked)
+        account = order.hold_account!
+        account.unlock_funds!(order.locked)
         order.record_cancel_operations!
 
         order.update!(state: ::Order::CANCEL)
+        AMQP::Queue.enqueue_event("private", order.member&.uid, 'account', order.member_account.as_json_for_event_api)
       end
     end
 
@@ -188,6 +191,7 @@ class Order < ApplicationRecord
     AMQP::Queue.enqueue(:order_processor,
                         { action: 'submit', order: attributes },
                         { persistent: false })
+    AMQP::Queue.enqueue_event("private", member&.uid, 'account', member_account.as_json_for_event_api)
   end
 
   def trigger_third_party_creation
@@ -226,6 +230,7 @@ class Order < ApplicationRecord
     return unless ord_type == 'limit' || state == 'done'
 
     ::AMQP::Queue.enqueue_event('private', member&.uid, 'order', for_notify)
+    ::AMQP::Queue.enqueue_event('private', member&.uid, 'account', member_account.as_json_for_event_api)
   end
 
   def side
@@ -350,7 +355,11 @@ class Order < ApplicationRecord
   end
 
   def member_balance
-    member.get_account(currency).balance
+    member_account.balance
+  end
+
+  def member_account
+    member.get_account(currency)
   end
 
   private

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -343,7 +343,10 @@ describe Order, '#trigger_event' do
       }
     end
 
-    before { ::AMQP::Queue.expects(:enqueue_event).with('private', subject.member.uid, 'order', data) }
+    before do
+      ::AMQP::Queue.expects(:enqueue_event).with('private', subject.member.uid, 'order', data)
+      ::AMQP::Queue.expects(:enqueue_event).with('private', subject.member.uid, 'account', anything)
+    end
 
     it { subject.trigger_event }
   end
@@ -387,6 +390,7 @@ describe Order, '#trigger_event' do
       it do
         subject.update!(state: 'done')
         ::AMQP::Queue.expects(:enqueue_event).with('private', subject.member.uid, 'order', data)
+        ::AMQP::Queue.expects(:enqueue_event).with('private', subject.member.uid, 'account', anything)
         subject.trigger_event
       end
     end

--- a/spec/serializers/serializers/event_api/order_canceled_spec.rb
+++ b/spec/serializers/serializers/event_api/order_canceled_spec.rb
@@ -59,6 +59,7 @@ describe Serializers::EventAPI::OrderCanceled do
       created_at:              created_at.iso8601,
       canceled_at:             canceled_at.iso8601
     }).once
+    EventAPI.expects(:enqueue_event).with("private.#{seller.uid}.account", anything)
   end
 
   after do

--- a/spec/serializers/serializers/event_api/order_completed_spec.rb
+++ b/spec/serializers/serializers/event_api/order_completed_spec.rb
@@ -61,6 +61,7 @@ describe Serializers::EventAPI::OrderCompleted do
       created_at:              created_at.iso8601,
       completed_at:            completed_at.iso8601
     }).once
+    EventAPI.expects(:enqueue_event).with("private.#{seller.uid}.account", anything)
   end
 
   after do

--- a/spec/serializers/serializers/event_api/order_completed_spec.rb
+++ b/spec/serializers/serializers/event_api/order_completed_spec.rb
@@ -36,6 +36,10 @@ describe Serializers::EventAPI::OrderCompleted do
   before do
     DatabaseCleaner.clean
     EventAPI.expects(:notify).with('market.btcusd.order_created', anything).once
+    AMQP::Queue.expects(:enqueue_event).with("private", seller.uid, "order", anything)
+    # side effect, publish account updated state
+    AMQP::Queue.expects(:enqueue_event).with("private", seller.uid, "account", anything)
+
     EventAPI.expects(:notify).with('market.btcusd.order_completed', {
       id:                      1,
       market:                  'btcusd',
@@ -61,7 +65,9 @@ describe Serializers::EventAPI::OrderCompleted do
       created_at:              created_at.iso8601,
       completed_at:            completed_at.iso8601
     }).once
-    EventAPI.expects(:enqueue_event).with("private.#{seller.uid}.account", anything)
+    AMQP::Queue.expects(:enqueue_event).with("private", seller.uid, "order", anything)
+    # side effect, publish account updated state
+    AMQP::Queue.expects(:enqueue_event).with("private", seller.uid, "account", anything)
   end
 
   after do

--- a/spec/serializers/serializers/event_api/order_created_spec.rb
+++ b/spec/serializers/serializers/event_api/order_created_spec.rb
@@ -55,6 +55,7 @@ describe Serializers::EventAPI::OrderCreated do
       trades_count:           0,
       created_at:             created_at.iso8601
     }).once
+    EventAPI.expects(:enqueue_event).with("private.#{buyer.uid}.account", anything)
   end
 
   after do

--- a/spec/serializers/serializers/event_api/order_updated_spec.rb
+++ b/spec/serializers/serializers/event_api/order_updated_spec.rb
@@ -61,6 +61,7 @@ describe Serializers::EventAPI::OrderUpdated, OrderAsk do
       created_at:              created_at.iso8601,
       updated_at:              updated_at.iso8601
     }).once
+    EventAPI.expects(:enqueue_event).with("private.#{seller.uid}.account", anything)
   end
 
   after do
@@ -138,6 +139,7 @@ describe Serializers::EventAPI::OrderUpdated, OrderBid do
       created_at:              created_at.iso8601,
       updated_at:              updated_at.iso8601
     }).once
+    EventAPI.expects(:enqueue_event).with("private.#{buyer.uid}.account", anything)
   end
 
   after do

--- a/spec/serializers/serializers/event_api/order_updated_spec.rb
+++ b/spec/serializers/serializers/event_api/order_updated_spec.rb
@@ -36,6 +36,10 @@ describe Serializers::EventAPI::OrderUpdated, OrderAsk do
   before do
     DatabaseCleaner.clean
     EventAPI.expects(:notify).with('market.btcusd.order_created', anything)
+    AMQP::Queue.expects(:enqueue_event).with("private", seller.uid, "order", anything)
+    # side effect, publish account updated state
+    AMQP::Queue.expects(:enqueue_event).with("private", seller.uid, "account", anything)
+
     EventAPI.expects(:notify).with('market.btcusd.order_updated', {
       id:                      1,
       market:                  'btcusd',
@@ -61,7 +65,9 @@ describe Serializers::EventAPI::OrderUpdated, OrderAsk do
       created_at:              created_at.iso8601,
       updated_at:              updated_at.iso8601
     }).once
-    EventAPI.expects(:enqueue_event).with("private.#{seller.uid}.account", anything)
+    AMQP::Queue.expects(:enqueue_event).with("private", seller.uid, "order", anything)
+    # side effect, publish account updated state
+    AMQP::Queue.expects(:enqueue_event).with("private", seller.uid, "account", anything)
   end
 
   after do
@@ -113,7 +119,12 @@ describe Serializers::EventAPI::OrderUpdated, OrderBid do
 
   before do
     DatabaseCleaner.clean
+    EventAPI.expects(:notify).with('model.account.created', anything).once
     EventAPI.expects(:notify).with('market.btcusd.order_created', anything)
+    AMQP::Queue.expects(:enqueue_event).with("private", buyer.uid, "order", anything)
+    # side effect, publish account updated state
+    AMQP::Queue.expects(:enqueue_event).with("private", buyer.uid, "account", anything)
+
     EventAPI.expects(:notify).with('market.btcusd.order_updated', {
       id:                      1,
       market:                  'btcusd',
@@ -139,7 +150,9 @@ describe Serializers::EventAPI::OrderUpdated, OrderBid do
       created_at:              created_at.iso8601,
       updated_at:              updated_at.iso8601
     }).once
-    EventAPI.expects(:enqueue_event).with("private.#{buyer.uid}.account", anything)
+    AMQP::Queue.expects(:enqueue_event).with("private", buyer.uid, "order", anything)
+    # side effect, publish account updated state
+    AMQP::Queue.expects(:enqueue_event).with("private", buyer.uid, "account", anything)
   end
 
   after do

--- a/spec/serializers/serializers/event_api/trade_completed_spec.rb
+++ b/spec/serializers/serializers/event_api/trade_completed_spec.rb
@@ -125,6 +125,8 @@ describe Serializers::EventAPI::TradeCompleted, 'Event API' do
         taker_outcome_fee:      '0.0',
         completed_at:           completed_at.iso8601
       }).once
+      EventAPI.expects(:enqueue_event).with("private.#{maker.uid}.account", anything)
+      EventAPI.expects(:enqueue_event).with("private.#{taker.uid}.account", anything)
     end
 
     after do
@@ -195,6 +197,8 @@ describe Serializers::EventAPI::TradeCompleted, 'Event API' do
         taker_outcome_fee:      '0.0',
         completed_at:           completed_at.iso8601
       }).once
+      EventAPI.expects(:enqueue_event).with("private.#{maker.uid}.account", anything)
+      EventAPI.expects(:enqueue_event).with("private.#{taker.uid}.account", anything)
     end
 
     after do

--- a/spec/serializers/serializers/event_api/trade_completed_spec.rb
+++ b/spec/serializers/serializers/event_api/trade_completed_spec.rb
@@ -102,8 +102,22 @@ describe Serializers::EventAPI::TradeCompleted, 'Event API' do
       DatabaseCleaner.clean
       EventAPI.expects(:notify).with('model.account.created', anything).twice
       EventAPI.expects(:notify).with('market.btcusd.order_created', anything).twice
+      AMQP::Queue.expects(:enqueue_event).with("private", maker.uid, "order", anything)
+      AMQP::Queue.expects(:enqueue_event).with("private", taker.uid, "order", anything)
+      # side effect, publish account updated state
+      AMQP::Queue.expects(:enqueue_event).with("private", maker.uid, "account", anything)
+      AMQP::Queue.expects(:enqueue_event).with("private", taker.uid, "account", anything)
+
       EventAPI.expects(:notify).with('market.btcusd.order_updated', anything).once
+      AMQP::Queue.expects(:enqueue_event).with("private", maker.uid, "order", anything)
+      # side effect, publish account updated state
+      AMQP::Queue.expects(:enqueue_event).with("private", maker.uid, "account", anything)
+
       EventAPI.expects(:notify).with('market.btcusd.order_completed', anything).once
+      AMQP::Queue.expects(:enqueue_event).with("private", taker.uid, "order", anything)
+      # side effect, publish account updated state
+      AMQP::Queue.expects(:enqueue_event).with("private", taker.uid, "account", anything)
+
       EventAPI.expects(:notify).with('market.btcusd.trade_completed', {
         id:                     1,
         market:                 'btcusd',
@@ -125,8 +139,9 @@ describe Serializers::EventAPI::TradeCompleted, 'Event API' do
         taker_outcome_fee:      '0.0',
         completed_at:           completed_at.iso8601
       }).once
-      EventAPI.expects(:enqueue_event).with("private.#{maker.uid}.account", anything)
-      EventAPI.expects(:enqueue_event).with("private.#{taker.uid}.account", anything)
+      AMQP::Queue.expects(:enqueue_event).with("public", 'btcusd', "trades", anything)
+      AMQP::Queue.expects(:enqueue_event).with("private", maker.uid, "trade", anything)
+      AMQP::Queue.expects(:enqueue_event).with("private", taker.uid, "trade", anything)
     end
 
     after do
@@ -174,8 +189,22 @@ describe Serializers::EventAPI::TradeCompleted, 'Event API' do
       DatabaseCleaner.clean
       EventAPI.expects(:notify).with('model.account.created', anything).twice
       EventAPI.expects(:notify).with('market.btcusd.order_created', anything).twice
+      AMQP::Queue.expects(:enqueue_event).with("private", maker.uid, "order", anything)
+      AMQP::Queue.expects(:enqueue_event).with("private", taker.uid, "order", anything)
+      # side effect, publish account updated state
+      AMQP::Queue.expects(:enqueue_event).with("private", maker.uid, "account", anything)
+      AMQP::Queue.expects(:enqueue_event).with("private", taker.uid, "account", anything)
+
       EventAPI.expects(:notify).with('market.btcusd.order_updated', anything).once
+      AMQP::Queue.expects(:enqueue_event).with("private", maker.uid, "order", anything)
+      # side effect, publish account updated state
+      AMQP::Queue.expects(:enqueue_event).with("private", maker.uid, "account", anything)
+
       EventAPI.expects(:notify).with('market.btcusd.order_completed', anything).once
+      AMQP::Queue.expects(:enqueue_event).with("private", taker.uid, "order", anything)
+      # side effect, publish account updated state
+      AMQP::Queue.expects(:enqueue_event).with("private", taker.uid, "account", anything)
+
       EventAPI.expects(:notify).with('market.btcusd.trade_completed', {
         id:                     1,
         market:                 'btcusd',
@@ -197,8 +226,10 @@ describe Serializers::EventAPI::TradeCompleted, 'Event API' do
         taker_outcome_fee:      '0.0',
         completed_at:           completed_at.iso8601
       }).once
-      EventAPI.expects(:enqueue_event).with("private.#{maker.uid}.account", anything)
-      EventAPI.expects(:enqueue_event).with("private.#{taker.uid}.account", anything)
+      # AMQP::Queue.expects(:enqueue_event).at_most 
+      AMQP::Queue.expects(:enqueue_event).with("public", 'btcusd', "trades", anything)
+      AMQP::Queue.expects(:enqueue_event).with("private", maker.uid, "trade", anything)
+      AMQP::Queue.expects(:enqueue_event).with("private", taker.uid, "trade", anything)
     end
 
     after do

--- a/spec/serializers/serializers/event_api/trade_completed_spec.rb
+++ b/spec/serializers/serializers/event_api/trade_completed_spec.rb
@@ -226,7 +226,6 @@ describe Serializers::EventAPI::TradeCompleted, 'Event API' do
         taker_outcome_fee:      '0.0',
         completed_at:           completed_at.iso8601
       }).once
-      # AMQP::Queue.expects(:enqueue_event).at_most 
       AMQP::Queue.expects(:enqueue_event).with("public", 'btcusd', "trades", anything)
       AMQP::Queue.expects(:enqueue_event).with("private", maker.uid, "trade", anything)
       AMQP::Queue.expects(:enqueue_event).with("private", taker.uid, "trade", anything)


### PR DESCRIPTION
#8 
- [x] - order submit/complete/update events
- [x] - trade executor event
- [ ] - deposit events
- [ ] - withdraw events
- [ ] - other txs types

Specs are implemented too.
@dapi, consider merging alt PR #24 instead, #24 in addition to above has mysql context removed for the purpose of mocking mysql hardcoded tests.