### PR TITLE
Updated currencies seed template to list ERC-20 tokens

### DIFF
--- a/config/templates/seed/currencies.yml.erb
+++ b/config/templates/seed/currencies.yml.erb
@@ -1,43 +1,6 @@
 <% if ENV['CURRENCIES_CONFIG'] %>
 <%= File.read(ENV['CURRENCIES_CONFIG']) %>
 <% else %>
-- id:                     usd
-  name:                   US Dollar
-  type:                   fiat
-  precision:              2
-  base_factor:            1
-  visible:                true
-  deposit_enabled:        true
-  withdrawal_enabled:     true
-  min_deposit_amount:     0
-  min_collection_amount:  0
-  withdraw_limit_24h:     100
-  withdraw_limit_72h:     200
-  deposit_fee:            0
-  withdraw_fee:           0
-  position:               1
-  options:                {}
-
-- id:                     btc
-  name:                   Bitcoin
-  blockchain_key:         btc-testnet
-  type:                   coin
-  precision:              8
-  base_factor:            100_000_000
-  visible:                true
-  deposit_enabled:        true
-  withdrawal_enabled:     true
-  # Deposits with less amount are skipped during blockchain synchronization.
-  # We advise to set value 10 times bigger than the network fee to prevent losses.
-  min_deposit_amount:     0.0000356
-  min_collection_amount:  0.0000356
-  withdraw_limit_24h:     0.1
-  withdraw_limit_72h:     0.2
-  deposit_fee:            0
-  withdraw_fee:           0
-  position:               2
-  options:                {}
-
 - id:                     eth
   name:                   Ethereum
   blockchain_key:         eth-rinkeby
@@ -55,7 +18,7 @@
   withdraw_limit_72h:     0.5
   deposit_fee:            0
   withdraw_fee:           0
-  position:               3
+  position:               4
   options:
     # ETH tx fees configurations.
     #
@@ -64,36 +27,71 @@
     # Internal price that is paid for running a transaction on the Ethereum network.
     gas_price: 1_000_000_000
 
-- id:                     trst
-  name:                   WeTrust
-  blockchain_key:         eth-rinkeby
+  <% (%w[
+    USDT	0xdac17f958d2ee523a2206206994597c13d831ec7	6	  45
+    MCR	  0xed351575b9869aada94435e0066ba38e08800b60	18	1000
+    USDC	0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48	6	  45
+    UNI	  0x1f9840a85d5af5bf1d1762f925bdaddc4201f984	18	2.5
+    BUSD	0x4fabb145d64652a948d72533023f6e7a623c7c53	18	45
+    LINK	0x514910771af9ca656af840dff83e8264ecf986ca	18	3
+    WBTC	0x2260fac5e5542a773aa44fbcfedf7c193bc2c599	8	  0.00005
+    DAI	  0x6b175474e89094c44da98b954eedeac495271d0f	18	45
+    LUNA	0xd2877702675e6ceb975b4a1dff9fb7baf4c91ea9	18	5
+    MKR	  0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2	18	0.005
+    COMP	0xc00e94cb662c3520282e6f5717214004a7f26888	18	0.1
+    TUSD	0x0000000000085d4780B73119b644AE5ecd22b376	18	45
+    SNX	  0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f	18	4
+    YFI	  0x0bc529c00C6401aEF6D220BE8C6Ea1667F6Ad93e	18	0.0001
+    SUSHI	0x6b3595068778dd592e39a122f4f5a5cf09c90fe2	18	4
+    PAX	  0x8e870d67f660d95d5be530380d0ec0bd388289e1	18	45
+    BNT	  0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c	18	20
+    CRV	  0xD533a949740bb3306d119CC777fa900bA034cd52	18	20
+    ZRX	  0xe41d2489571d322189246dafa5ebde1f4699f498	18	50
+    1INCH	0x111111111117dc0aa78b770fa6a738034120c302	18	20
+    MDT	  0x4dfd148b532e934a2a26ea65689cf6268753e130	18	25
+  ]).each_slice(4).map do |token_raw|
+    Hash[
+      %i[
+        id erc20_contract_address base_factor min_deposit_amount
+      ].zip(token_raw)
+    ]
+  end.map do |params|
+    params[:id] = params[:id].downcase
+    params[:base_factor] = params[:base_factor].to_i.to_s.chars.to_a.reverse.each_slice(3).map(&:join).join('_').reverse
+    params[:min_deposit_amount] = params[:min_deposit_amount].to_f
+    params
+  end.each_with_index do |params, index| %>
+- id:                     <%= params[:id] %>
+  name:                   Tether ERC-20
+  blockchain_key:         eth-mainnet
   parent_id:              eth
   type:                   coin
-  precision:              8
-  base_factor:            1_000_000 # IMPORTANT: Don't forget to update this variable according
+  precision:              6
+  base_factor:            <%= params[:base_factor] %> # IMPORTANT: Don't forget to update this variable according
                                     # to your ERC20-based currency requirements
                                     # (usually can be found on the official website).
-  visible:                true
-  deposit_enabled:        true
-  withdrawal_enabled:     true
+  visible:                false
+  deposit_enabled:        false
+  withdrawal_enabled:     false
   # Deposits with less amount are skipped during blockchain synchronization.
   # We advise to set value 10 times bigger than the network fee to prevent losses.
   # NOTE: Network fee is paid in ETH but min_deposit_amount is in TRST.
-  min_deposit_amount:     2
-  min_collection_amount:  2
-  withdraw_limit_24h:     300
-  withdraw_limit_72h:     600
+  min_deposit_amount:     <%= params[:min_deposit_amount] %>
+  min_collection_amount:  <%= params[:min_deposit_amount] * 3 %>
+  withdraw_limit_24h:     <%= params[:min_deposit_amount] * 150 %>
+  withdraw_limit_72h:     <%= params[:min_deposit_amount] * 300 %>
   deposit_fee:            0
   withdraw_fee:           0
-  position:               4
+  position:               <%= index + 7 %>
   options:
     # ERC20 tx fees configurations.
     #
     # Maximum amount of gas you're willing to spend on a particular transaction.
     gas_limit: 90_000
     # Internal price that is paid for running a contract on the Ethereum network.
-    gas_price: 1_000_000_000
+    gas_price: 42_000_000_000
     #
     # ERC20 configuration.
-    erc20_contract_address: '0x0000000000000000000000000000000000000000' # Always wrap this value in quotes!
+    erc20_contract_address: '<%= params[:erc20_contract_address] %>' # Always wrap this value in quotes!
+  <% end %>
 <% end %>


### PR DESCRIPTION
# Usage

Execute `bin/init_config` to render all templates along with currencies.

Concerning db dump `peatio_production_2021-07-12-135541.sql`

Don't forget to remove old tokens USDT and MCR before seeding.

Currencies position values are set according to positions of USDT and MCR and ascesnds drom this point.

USDT and MCR moved to the top of the list, so that they are seeded first.
