### PR TITLE
Cancel member orders on disconnect

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -7,5 +7,6 @@ trade_executor: RAILS_ROOT=. bundle exec ruby ./lib/daemons/amqp_daemon.rb trade
 influx_writer: RAILS_ROOT=. bundle exec ruby ./lib/daemons/amqp_daemon.rb influx_writer
 deposit_intention: RAILS_ROOT=. bundle exec ruby ./lib/daemons/amqp_daemon.rb deposit_intention
 create_order: RAILS_ROOT=. bundle exec ruby ./lib/daemons/amqp_daemon.rb create_order
+cancel_member_orders: RAILS_ROOT=. bundle exec ruby ./lib/daemons/amqp_daemon.rb cancel_member_orders
 
 web: bundle exec rails server -b 0.0.0.0 -p 3000

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -168,6 +168,10 @@ class Order < ApplicationRecord
     end
   end
 
+  def cancel!
+    Order.cancel(id)
+  end
+
   def trigger_third_party_creation
     self.uuid ||= UUID.generate
     self.created_at ||= Time.now

--- a/app/workers/amqp/cancel_member_orders.rb
+++ b/app/workers/amqp/cancel_member_orders.rb
@@ -1,0 +1,18 @@
+# encoding: UTF-8
+# frozen_string_literal: true
+
+module Workers
+  module AMQP
+    class CancelMemberOrders < Base
+      def process(payload)
+        payload.symbolize_keys!
+        member_uid = payload[:member_uid]
+        member = ::Member.find_by!(uid: member_uid)
+
+        member.orders.active.each(&:cancel!)
+      rescue ActiveRecord::RecordNotFound => e
+        report_exception(e, true, payload)
+      end
+    end
+  end
+end

--- a/config/amqp.yml
+++ b/config/amqp.yml
@@ -58,6 +58,9 @@ queue:
   create_order:
     name: peatio.ranger.new_orders
     durable: true
+  cancel_orders:
+    name: peatio.ranger.cancel_orders
+    durable: true
   order_processor:
     name: peatio.order.processor
     durable: true
@@ -117,6 +120,10 @@ binding:
   events_processor:
     queue: events_processor
     exchange: events
+  cancel_member_orders:
+    queue: cancel_orders
+    exchange: ranger
+    topics: peatio.ranger.cancel_orders
 
 channel:
   trade_executor:

--- a/spec/workers/amqp/cancel_member_orders_spec.rb
+++ b/spec/workers/amqp/cancel_member_orders_spec.rb
@@ -11,24 +11,24 @@ describe Workers::AMQP::CancelMemberOrders do
 
   let!(:ask_orders) do
     create(
-      :order_ask, :btcusd,
+      :order_ask, :btc_usd,
       price: '1', volume: '1.0', state: :wait,
       member: member
     )
     create(
-      :order_ask, :btcusd,
+      :order_ask, :btc_usd,
       price: '1', volume: '1.0', state: :wait,
       member: member
     )
   end
   let!(:bid_orders) do
     create(
-      :order_bid, :btcusd,
+      :order_bid, :btc_usd,
       price: '1', volume: '1.0', state: :wait,
       member: member
     )
     create(
-      :order_bid, :btcusd,
+      :order_bid, :btc_usd,
       price: '1', volume: '1.0', state: :wait,
       member: member
     )

--- a/spec/workers/amqp/cancel_member_orders_spec.rb
+++ b/spec/workers/amqp/cancel_member_orders_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+describe Workers::AMQP::CancelMemberOrders do
+  let!(:member) { create(:member, :level_3) }
+  let!(:account) {
+    create(:account, :usd, balance: 100.to_d, locked: 2.to_d, member: member)
+  }
+  let!(:account1) {
+    create(:account, :btc, balance: 100.to_d, locked: 2.to_d, member: member)
+  }
+
+  let!(:ask_orders) do
+    create(
+      :order_ask, :btcusd,
+      price: '1', volume: '1.0', state: :wait,
+      member: member
+    )
+    create(
+      :order_ask, :btcusd,
+      price: '1', volume: '1.0', state: :wait,
+      member: member
+    )
+  end
+  let!(:bid_orders) do
+    create(
+      :order_bid, :btcusd,
+      price: '1', volume: '1.0', state: :wait,
+      member: member
+    )
+    create(
+      :order_bid, :btcusd,
+      price: '1', volume: '1.0', state: :wait,
+      member: member
+    )
+  end
+
+  subject { Workers::AMQP::CancelMemberOrders.new }
+
+  describe '#perform' do
+    it 'cancels all active member orders' do
+      expect {
+        subject.process({
+          event: 'close_all_orders',
+          member_uid: member.uid
+        })
+      }.to change { member.orders.active.count }.from(4).to(0)
+    end
+  end
+end


### PR DESCRIPTION
[Закрывать (cancel) все сделки у пользователя по событию cancel on close](https://github.com/bitzlato/peatio/issues/74)

Exchange: стандартный для rango `peatio.ranger`
Routing key для exchange: `peatio.ranger.cancel_orders`

@dapi создал PR пока в `feature/create_order_amqp` а не в мастер чтобы лишних коммитов не было, мержить после https://github.com/bitzlato/peatio/pull/39 в мастер уже