### PR TITLE
Feature/market specific matching

### DIFF
--- a/.semver
+++ b/.semver
@@ -1,6 +1,6 @@
 ---
 :major: 3
-:minor: 3
-:patch: 6
+:minor: 4
+:patch: 0
 :special: ''
 :metadata: ''

--- a/app/jobs/cron/bargainer_job.rb
+++ b/app/jobs/cron/bargainer_job.rb
@@ -3,19 +3,19 @@
 module Jobs
   module Cron
     class BargainerJob
-      JOB_TIMEOUT = Rails.env.production? ? 30.seconds : 5.seconds
+      TIMEOUT_RANGE = (3.0..10.0).freeze
 
       MIN_VOLUME = 0.0005
       MAX_VOLUME = 0.001
       PRICE_DEVIATION = 0.001
 
-      def self.process(job_timeout = JOB_TIMEOUT)
+      def self.process(timeout_range = TIMEOUT_RANGE)
         Rails.logger.info { 'Start bargainer process' }
         market = Market.find_by!(symbol: ENV.fetch('BARGAINER_MARKET_SYMBOL', 'btc_usdterc20'))
         member = Member.find_by!(uid: ENV['BARGAINER_UID'])
         Bargainer.new.call(market: market, member: member, min_volume: MIN_VOLUME, max_volume: MAX_VOLUME, price_deviation: PRICE_DEVIATION)
 
-        sleep(job_timeout + Random.rand(10) - 5)
+        sleep rand timeout_range
       end
     end
   end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -160,7 +160,14 @@ class Order < ApplicationRecord
 
     touch :canceling_at
     # TODO: Зачем для отмены передавать все параметры? Достаточно только ID. Осталное можно подгрузить уже в order_processor
-    AMQP::Queue.enqueue(:matching, action: 'cancel', order: to_matching_attributes)
+    if Peatio::App.config.market_specific_workers
+      AMQP::Queue.enqueue(:matching,
+                          { action: 'cancel', order: to_matching_attributes },
+                          {},
+                          market_id)
+    else
+      AMQP::Queue.enqueue(:matching, { action: 'cancel', order: to_matching_attributes })
+    end
   end
 
   def trigger_third_party_cancellation

--- a/app/services/bargainer.rb
+++ b/app/services/bargainer.rb
@@ -10,8 +10,12 @@ class Bargainer
     price = average_price(market, price_deviation)
     cancel_member_orders(member, market)
     if price.nil?
-      Rails.logger.info { { message: 'No price to bargain. Cancel process', service: 'bargainer' } }
-      return
+      if Rails.env.sandbox?
+        price = market.trades.last.price
+      else
+        Rails.logger.info { { message: 'No price to bargain. Cancel process', service: 'bargainer' } }
+        return
+      end
     end
 
     sides = %w[buy sell].shuffle

--- a/app/trading/matching/executor.rb
+++ b/app/trading/matching/executor.rb
@@ -38,7 +38,10 @@ module Matching
         order.with_lock do
           next unless order.state == Order::WAIT
 
-          AMQP::Queue.enqueue(:matching, action: 'submit', order: order.to_matching_attributes)
+          AMQP::Queue.enqueue(:matching,
+                              { action: 'submit', order: order.to_matching_attributes },
+                              {},
+                              Peatio::App.config.market_specific_workers ? order.market_id : nil)
         end
       end
       report_exception_to_screen(e)

--- a/app/workers/amqp/matching.rb
+++ b/app/workers/amqp/matching.rb
@@ -14,11 +14,13 @@ module Workers
       def initialize(options = {})
         if options.is_a? String
           raise 'Wrong market specific settings' unless Peatio::App.config.market_specific_workers
+
           @market = options
           @options = {}
           reload @market
         else
           raise 'Wrong market specific settings' if Peatio::App.config.market_specific_workers
+
           @options = options
           @market = nil
           reload 'all'

--- a/app/workers/amqp/matching.rb
+++ b/app/workers/amqp/matching.rb
@@ -13,10 +13,12 @@ module Workers
 
       def initialize(options = {})
         if options.is_a? String
+          raise 'Wrong market specific settings' unless Peatio::App.config.market_specific_workers
           @market = options
           @options = {}
           reload @market
         else
+          raise 'Wrong market specific settings' if Peatio::App.config.market_specific_workers
           @options = options
           @market = nil
           reload 'all'

--- a/app/workers/amqp/order_processor.rb
+++ b/app/workers/amqp/order_processor.rb
@@ -60,7 +60,10 @@ module Workers
           order.record_submit_operations!
           order.update!(state: ::Order::WAIT)
 
-          ::AMQP::Queue.enqueue(:matching, action: 'submit', order: order.to_matching_attributes)
+          ::AMQP::Queue.enqueue(:matching,
+                                { action: 'submit', order: order.to_matching_attributes },
+                                {},
+                                Peatio::App.config.market_specific_workers ? order.market_id : nil)
         end
       rescue StandardError => e
         report_exception e, true, order_id: id


### PR DESCRIPTION
```
cap $STAGE systemd:puma:stop
# проверяем что очереди order_processor и matching пусты
cap $STAGE systemd:market_amqp_daemon:stop \
systemd:amqp_daemon:stop systemd:amqp_daemon:disable systemd:amqp_daemon:remove \
systemd:amqp_daemon:setup systemd:market_amqp_daemon:setup
cap $STAGE deploy
# удалить очередь peatio.matching
```